### PR TITLE
Process markdown files as Nunjucks

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -35,4 +35,7 @@ module.exports = function(eleventyConfig) {
 
     return links.join("<span aria-hidden='true'> / </span>");
   })
+  return {
+    markdownTemplateEngine: "njk"
+  }
 };


### PR DESCRIPTION
By default Elventy processses markdown files from the Liquid templating language first, meaning you can use templating syntax within markdown files. We currently aren't using any templating inside markdown files but if we do in future it might be confusing to contributors as the Liquid syntax is slightly different to Nunjucks, our primary templating language.