### PR TITLE
Tidy up the homepage phases a little.

### DIFF
--- a/_includes/assets/sass/components/_phase-rows.scss
+++ b/_includes/assets/sass/components/_phase-rows.scss
@@ -19,4 +19,14 @@
   *:nth-child(n + 7) {
     grid-area: d / auto;
   }
+
+  li {
+    margin-bottom: $tbds-space-6;
+  }
+}
+
+.phase {
+  h3 {
+    margin-top: 0;
+  }
 }

--- a/index.njk
+++ b/index.njk
@@ -35,7 +35,8 @@ layout: 'layouts/base'
   </div>
 </section>
 
-<section>
+<section class="tbds-block-stack tbds-block-stack--gap-5">
+  <div class="tbds-block-stack__item">
   <h2>Design sprint phases</h2>
   <p class="measure">
     At its core, a design sprint is split into 5 phases. Each phase has a clear
@@ -43,14 +44,14 @@ layout: 'layouts/base'
     validating big ideas. Each phase is flexible and there is lots of room to
     experiment with different techniques.
   </p>
-  <ul class="phase-rows" id="phases">
+  </div>
+  <ul class="tbds-block-stack__item phase-rows" id="phases">
     {% for phase in collections.phase %}
-      <li>
-        <a href="{{ phase.data.page.url }}">
-          <img src="#" alt="">
-          <span class="eyebrow">Phase {{ phase.data.number }}</span>
-          <h3>{{ phase.data.title }}</h3>
-        </a>
+      <li class="phase">
+        <span class="eyebrow">Phase {{ phase.data.number }}</span>
+        <h3>
+          <a href="{{ phase.data.page.url }}">{{ phase.data.title }}</a>
+        </h3>
       </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
This just makes the phases a little bit tidier visually, just in case we don't get around to redesigning them completely before the launch.

**Screenshots**

<details><summary>Before</summary>

<!-- Image here -->
<img width="1904" alt="Screenshot 2022-12-09 at 15 13 40" src="https://user-images.githubusercontent.com/1729878/206733422-33ec98ea-c722-4160-b30e-427ffaad8240.png">

</details>

<details><summary>After</summary>

<!-- Image here -->
<img width="1904" alt="Screenshot 2022-12-09 at 15 13 16" src="https://user-images.githubusercontent.com/1729878/206733345-5cb71c0b-4803-4e46-8a6b-34362219f5bb.png">

</details>
