### PR TITLE
Fix 404-ing indexes

### DIFF
--- a/resources/index/index.njk
+++ b/resources/index/index.njk
@@ -1,4 +1,5 @@
 ---
+permalink: "resources/index.html"
 eleventyExcludeFromCollections: true
 ---
 

--- a/schedules/index/index.njk
+++ b/schedules/index/index.njk
@@ -1,4 +1,5 @@
 ---
+permalink: "schedules/index.html"
 eleventyExcludeFromCollections: true
 ---
 


### PR DESCRIPTION
The resources & schedules indexes were 404-ing due to a missing permalink front-matter.