### PR TITLE
Move Resources list into Markdown

### DIFF
--- a/resources/blog-posts.md
+++ b/resources/blog-posts.md
@@ -1,5 +1,0 @@
----
-title: Our Blog Posts
----
-
-[Blog posts tagged 'design'](https://thoughtbot.com/blog/design)

--- a/resources/index/_list.md
+++ b/resources/index/_list.md
@@ -1,0 +1,10 @@
+* [Our Blog Posts](https://thoughtbot.com/blog/design)
+* [Sprint Book](https://www.thesprintbook.com/)
+* [Sprint Stories](https://sprintstories.com/)
+* [Design Sprint 2.0](https://www.invisionapp.com/inside-design/design-sprint-2/)
+* [Gamestorming](http://www.amazon.com/Gamestorming-Playbook-Innovators-Rulebreakers-Changemakers/dp/0596804172) and the [Gamestorming Wiki](http://www.gamestorming.com/the-wiki/)
+
+### Trello Templates
+
+* [Template based off original Sprint blog posts](https://trello.com/b/lMmuSlkP/public-design-sprint-template)
+* [Template based off Sprint Book](https://trello.com/b/76kqcT8s/gv-design-sprint-template)

--- a/resources/index/index.njk
+++ b/resources/index/index.njk
@@ -9,9 +9,7 @@ eleventyExcludeFromCollections: true
 </article>
 
 <h2>Resources</h2>
-{% for resource in collections.resource %}
-  <li><a href="{{ resource.data.page.url }}">{{ resource.data.title }}</a></li>
-{% endfor %}
+{% renderFile './resources/index/_list.md' %}
 
 <h2>Glossary</h2>
 {% for term in collections.glossary %}


### PR DESCRIPTION
Related to #38

Most of the resources we have are just links and don't need their own
page. If we want a page, then we can create a page and link to it.

This moves in the resources from
https://thoughtbot.com/playbook/validation/product-design-sprint
