### PR TITLE
Add schedule interviews

### DIFF
--- a/exercises/schedule-interviews.md
+++ b/exercises/schedule-interviews.md
@@ -1,0 +1,11 @@
+---
+tags: ['exercise', 'planning']
+title: Schedule 4–6 people for testing interviews
+---
+
+During the [Test phase](/phases/test), we'll be running user interviews and
+showing the prototype to 4–6 people.
+
+If users are already identified, we should set up the interviews as early as
+possible. If users aren't identified yet, we should hold off till after
+Understand phase.


### PR DESCRIPTION
Related to #39

This moves the documentation on scheduling interviews into the new
guide, and adds them to the planning stage as an exercise (that's how
all the stuff in the planning phase is). This makes it clear that
interviews should be scheduled during the planning phase _if possible_.
