### PR TITLE
Review Research

### DIFF
--- a/exercises/review-research.md
+++ b/exercises/review-research.md
@@ -1,0 +1,31 @@
+---
+tags: ['exercise', 'understand']
+title: Review Research
+---
+
+Sharing the knowledge of the business, competition, value proposition, customer,
+and any other relevant research to develop a common understanding of the context
+of which we’re working.
+
+## Requirements
+
+- **Estimated time needed**: 2-3 hours
+- **Team**: Facilitator, Note-taker, Stakeholders
+
+## Why should we do this exercise?
+
+This exercises helps us to identify the root cause of the problem we are trying
+to solve, rather than the apparent surface-level problem. Solving the root
+cause should be the goal of any Sprint or new product as it creates a better
+product with fewer wasted resources so it is absolutely crucial to know what
+your root problem is. Check out the example below to see exactly what we mean.
+
+## Instructions
+
+1. Quickly identify existing research to determine what research should be
+   shared throughout the day (10 minutes)
+2. Define the business & the customer (1 hour)
+3. Define the problem, the value proposition, Success (1 hour)
+4. Lightning demos of any existing product or competitors sites (45 minutes)
+
+


### PR DESCRIPTION
https://github.com/thoughtbot/design-sprint-guide/issues/55

This is an exercise in the old guide that was not yet brought over.

It might have been intentional as this is a broad exercise that can also
be broken down into several other exercises.

That being said, there are times where a less-structured overview of all
of the existing research and context might make sense.

Opening this PR for discussion. If we want to keep this, should it make
its way onto one of the schedules?

If we don't want to keep there, where should it redirect to?
