### PR TITLE
Always run the CMS on `npm start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,15 @@ npm install
 ```
 npm start
 ```
-This will start Eleventy and watch sass files, and reload the browser on changes.
+This will start Eleventy, watch sass files, run the CMS locally, and reload the browser on changes.
 
 ### Access the CMS
 
 We use [Netlify CMS](https://www.netlifycms.org) locally to make editing
-exercises, and schedules easier, to access the CMS
-run everything above, then in a another terminal window run:
+exercises, and schedules easier.
 
-```
-npx netlify-cms-proxy-server
-```
-
-Then open `localhost:8080/admin` in a browser, and tap 'Login' (no login required).
+To access the CMS run everything above. Then open `localhost:8080/admin` in a
+browser, and tap 'Login' (no login required).
 
 The CMS is optional, you can still edit everything manually if you want to.
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "watch:eleventy": "eleventy --serve",
+    "watch:cms": "npx netlify-cms-proxy-server",
     "build:eleventy": "eleventy",
     "watch:sass": "sass --load-path='node_modules/@thoughtbot' --watch _includes/assets/sass:./css",
     "build:sass": "sass --load-path='node_modules/@thoughtbot' _includes/assets/sass:./css --style compressed --no-source-map",


### PR DESCRIPTION
It's a little annoying to have to run another command in another window to get the CMS to work, this PR allows folks to simply run `npm start` to get started.