### PR TITLE
Add width constraint to content

### DIFF
--- a/_includes/assets/sass/components/_components.scss
+++ b/_includes/assets/sass/components/_components.scss
@@ -9,3 +9,4 @@
 @import "inline-stack";
 @import "schedule";
 @import "breadcrumb";
+@import "container";

--- a/_includes/assets/sass/components/_container.scss
+++ b/_includes/assets/sass/components/_container.scss
@@ -1,0 +1,5 @@
+.container {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 80rem;
+}

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/css/style.css">
   </head>
   <body>
-    <nav class="menu | tbds-inline-stack tbds-margin-block-3 tbds-margin-block-6@medium" aria-labelledby="primary navigation">
+    <nav class="menu | tbds-inline-stack tbds-margin-block-3 tbds-margin-block-6@medium container" aria-labelledby="primary navigation">
       <div class="logo tbds-inline-stack__item">
         <a href="/">
           <img src="/images/logo.svg" alt="thoughtbot logo" />
@@ -26,14 +26,14 @@
     </nav>
 
     {% if page.url !== "/" %}
-      <nav class="breadcrumb | tbds-margin-block-4 tbds-margin-block-6@medium" aria-labelledby="navigate back to the previous pages">{% breadcrumbs page.url %}</nav>
+      <nav class="breadcrumb | tbds-margin-block-4 tbds-margin-block-6@medium container" aria-labelledby="navigate back to the previous pages">{% breadcrumbs page.url %}</nav>
     {% endif %}
 
-    {% include "../banner.njk" %}
+    <div class="container">{% include "../banner.njk" %}</div>
 
-    {{ content | safe }}
+    <main class="container">{{ content | safe }}</main>
 
-    <nav class="menu | tbds-inline-stack tbds-margin-block-6" aria-labelledby="footer navigation">
+    <nav class="menu | tbds-inline-stack tbds-margin-block-6 container" aria-labelledby="footer navigation">
       <div class="logo tbds-inline-stack__item">
         <p>&copy; 2022 thoughtbot, inc.</p>
       </div>

--- a/_includes/layouts/exercise.njk
+++ b/_includes/layouts/exercise.njk
@@ -2,8 +2,10 @@
 layout: "layouts/base"
 ---
 
-<h1>{{ title }}</h1>
+<div class="container">
+  <h1>{{ title }}</h1>
 
-<article class="measure">
-{{ content | safe }}
-</article>
+  <article class="measure">
+  {{ content | safe }}
+  </article>
+</div>

--- a/_includes/layouts/exercise.njk
+++ b/_includes/layouts/exercise.njk
@@ -2,10 +2,8 @@
 layout: "layouts/base"
 ---
 
-<div class="container">
-  <h1>{{ title }}</h1>
+<h1>{{ title }}</h1>
 
-  <article class="measure">
-  {{ content | safe }}
-  </article>
-</div>
+<article class="measure">
+{{ content | safe }}
+</article>


### PR DESCRIPTION
Issue: https://github.com/thoughtbot/design-sprint-guide/issues/75

Constrains the content so it's not wider than 80rem. 

| Before | After |
| - | - |
| <img width="1800" alt="Screen Shot 2022-12-15 at 16 32 43" src="https://user-images.githubusercontent.com/13579950/207971457-a48e25b2-9d61-4ec7-be3f-6cc0bbdcef4a.png"> | <img width="1800" alt="Screen Shot 2022-12-15 at 16 32 32" src="https://user-images.githubusercontent.com/13579950/207971468-dabe6a93-5fe4-475c-b5a5-e43b415cda2f.png"> |