### PR TITLE
Fix sticky footer and banner width issues

### DIFF
--- a/_includes/assets/sass/components/_banner.scss
+++ b/_includes/assets/sass/components/_banner.scss
@@ -1,12 +1,10 @@
 .banner {
   background: lighten($tbds-brand-yellow-light, 10%);
   color: $tbds-brand-gray-dark;
-  margin-inline: auto;
   padding: {
     block: $tbds-space-2;
     inline: $tbds-space-2;
   };
-  text-align: center;
 
   @media (min-width: $tbds-breakpoint-medium) {
     padding: {
@@ -14,10 +12,14 @@
       inline: $tbds-space-3;
     };
   }
-
+  text-align: center;
 }
 
 .banner > p {
   font-size: 0.9rem;
   margin: 0;
+}
+
+.banner-container {
+  width: 100%;
 }

--- a/_includes/assets/sass/components/_banner.scss
+++ b/_includes/assets/sass/components/_banner.scss
@@ -19,7 +19,3 @@
   font-size: 0.9rem;
   margin: 0;
 }
-
-.banner-container {
-  width: 100%;
-}

--- a/_includes/assets/sass/components/_container.scss
+++ b/_includes/assets/sass/components/_container.scss
@@ -1,7 +1,7 @@
 //REMOVE - Was breaking sticky footer
 
-// .container {
-//   margin-left: auto;
-//   margin-right: auto;
-//   max-width: 80rem;
-// }
+.container {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 80rem;
+}

--- a/_includes/assets/sass/components/_menu.scss
+++ b/_includes/assets/sass/components/_menu.scss
@@ -1,6 +1,7 @@
 .menu {
   align-items: start;
   flex-direction: column;
+  width: 100%;
 
   .inline-list {
     border-left: 2px solid $tbds-brand-gray-light;

--- a/_includes/banner.njk
+++ b/_includes/banner.njk
@@ -1,3 +1,3 @@
-<div class="banner | tbds-margin-block-3">
+<div class="banner | tbds-margin-block-3 container">
   <p>We're building this in the open so things may get a little weird at times. Don't worry! If you stumble onto something broken, <a href="https://github.com/thoughtbot/design-sprint-guide/issues">raise an issue </a>and we'll get Ralph right on it.</p>
 </div>

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -29,7 +29,7 @@
       <nav class="breadcrumb | tbds-margin-block-4 tbds-margin-block-6@medium container" aria-labelledby="navigate back to the previous pages">{% breadcrumbs page.url %}</nav>
     {% endif %}
 
-    <div class="container">{% include "../banner.njk" %}</div>
+    <div>{% include "../banner.njk" %}</div>
 
     <main class="container">{{ content | safe }}</main>
 

--- a/index.njk
+++ b/index.njk
@@ -54,19 +54,6 @@ layout: 'layouts/base'
     {% include 'tabs.njk'%}
   </section>
 
-  <section class="tbds-padding-block-4" id="build-design-sprint">
-    <div class="measure">
-      <h2>Build a design sprint</h2>
-      <p>
-        At thoughtbot, we have organized many, many design sprints over the years and
-        found that there is no right way to plan one. Each client and every problem is
-        different and needs a slightly different approach. If you are new to design
-        sprints start with one of our example schedules, after that try exploring all
-        the exercises and try building your own.
-      </p>
-    </div>
-  </section>
-
   <section class="schedule__section tbds-inline-stack tbds-inline-stack--gap-6">
     <div class="tbds-inline-stack__item tbds-inline-size-60%"> 
       <h2 id="schedules">Build a design sprint</h2>
@@ -80,8 +67,8 @@ layout: 'layouts/base'
         <a href="/schedules">See all</a> 
       </article>
     </div>
-    <div class="tbds-inline-stack__item">
 
+    <div class="tbds-inline-stack__item">
       <ul class="tbds-block-stack__item schedule__grid">
         {% for key, schedule in schedules %}
          <li>


### PR DESCRIPTION
This PR does the following:

- Fix sticky footer and nav width issues
- Fix banner width issue

In both instances the width of the elements were collapsing. This PR makes sure the nav elements and banner component take up the screens full width.