### PR TITLE
Add simple sales CTA to footer of all pages

### DIFF
--- a/_includes/assets/sass/components/_button.scss
+++ b/_includes/assets/sass/components/_button.scss
@@ -1,0 +1,23 @@
+.button {
+  --primary-color: #{$tbds-brand-red};
+  --background-color: white;
+
+  background-color: var(--primary-color);
+  border-radius: 100rem;
+  box-shadow: 0 0 0 2px var(--background-color), 0 0 0 5px var(--background-color);
+  color: var(--background-color);
+  display: inline-block;
+  padding: $tbds-space-3 $tbds-space-4;
+  text-decoration: none;
+
+  &:focus,
+  &:hover {
+    box-shadow: 0 0 0 2px var(--background-color), 0 0 0 5px var(--primary-color);
+    color: var(--background-color);
+  }
+}
+
+.button--inverse {
+  --primary-color: white;
+  --background-color: #{$tbds-brand-red};
+}

--- a/_includes/assets/sass/components/_components.scss
+++ b/_includes/assets/sass/components/_components.scss
@@ -14,3 +14,5 @@
 @import "internal-pages";
 @import "home-page";
 @import "hero";
+@import "button";
+@import "cta";

--- a/_includes/assets/sass/components/_cta.scss
+++ b/_includes/assets/sass/components/_cta.scss
@@ -1,0 +1,8 @@
+.cta {
+  background-color: $tbds-brand-red;
+  border-radius: $tbds-space-3;
+  color: white;
+  margin-top: $tbds-space-6;
+  padding: $tbds-space-4 $tbds-space-4 $tbds-space-6;
+  width: 100%;
+}

--- a/_includes/assets/sass/components/_tabs.scss
+++ b/_includes/assets/sass/components/_tabs.scss
@@ -4,7 +4,7 @@
 
 .tab-container {
   background: $tbds-brand-gray-ultra-light;
-  border-radius: 0.5rem;
+  border-radius: $tbds-space-3;
   margin-block: 3rem;
   padding-block: 0.25rem;
   padding-inline: 1.5rem;

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -22,6 +22,7 @@
         <li class="tbds-inline-stack__item"><a href="/sprint-guide/exercises">Exercises</a></li>
         <li class="tbds-inline-stack__item"><a href="/sprint-guide/#faqs">FAQs</a></li>
         <li class="tbds-inline-stack__item"><a href="/sprint-guide/resources">Resources</a></li>
+        <li class="tbds-inline-stack__item"><a href="#contact">Contact Us</a></li>
       </ul>
     </nav>
 
@@ -33,6 +34,16 @@
 
     <main class="container">{{ content | safe }}</main>
 
+    <footer class="cta container" id="contact">
+      <h3>Hire expert designers to run your design sprint</h3>
+      <p class="measure">
+        We've lost count of how many successful design sprints we have run for our clients,
+        if you like everything you've read so far but aren't ready to take on the challenge yourself,
+        our team of designers can plan and faciliate the perfect design sprint for you.
+      </p>
+      <a class="button button--inverse" href="https://thoughtbot.com/hire-us">Let's talk!</a>
+    </footer>
+
     <nav class="menu | tbds-inline-stack tbds-margin-block-6 container" aria-labelledby="footer navigation" id="footer">
       <div class="logo tbds-inline-stack__item">
         <p>&copy; 2022 thoughtbot, inc.</p>
@@ -43,6 +54,7 @@
         <li class="tbds-inline-stack__item"><a href="/sprint-guide/exercises">Exercises</a></li>
         <li class="tbds-inline-stack__item"><a href="/sprint-guide/#faqs">FAQs</a></li>
         <li class="tbds-inline-stack__item"><a href="/sprint-guide/resources">Resources</a></li>
+        <li class="tbds-inline-stack__item"><a href="#contact">Contact Us</a></li>
       </ul>
     </nav>
     <script src="/js/main.js"></script>


### PR DESCRIPTION
Adds a simple CTA to all pages that links to the [hire us page](https://thoughtbot.com/hire-us).

<img width="1904" alt="Screenshot 2023-01-13 at 14 22 22" src="https://user-images.githubusercontent.com/1729878/212342072-56497425-1493-46f1-a993-e4960a6702fc.png">
