### PR TITLE
Documentation improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ new content guides below should be helpful.
 - Add a new [schedule](https://github.com/thoughtbot/design-sprint-guide/blob/main/DOCS/sprint-guide/adding-schedules.md)
 - Add a new [glossary term](https://github.com/thoughtbot/design-sprint-guide/blob/main/DOCS/sprint-guide/adding-glossary.md)
 - Add a new [FAQ](https://github.com/thoughtbot/design-sprint-guide/blob/main/DOCS/sprint-guide/adding-faq.md)
+- Add a new [resource](https://github.com/thoughtbot/design-sprint-guide/blob/main/DOCS/sprint-guide/adding-resource.md)
 
 ## Ideas
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,10 @@ new content guides below should be helpful.
 
 ## New Content
 
-- Add a new [exercise](https://github.com/thoughtbot/design-sprint-guide/blob/main/DOCS/adding-exercises.md)
-- Add a new [schedule](https://github.com/thoughtbot/design-sprint-guide/blob/main/DOCS/adding-schedules.md)
-- Add a new [glossary term](https://github.com/thoughtbot/design-sprint-guide/blob/main/DOCS/adding-glossary.md)
-- Add a new [FAQ](https://github.com/thoughtbot/design-sprint-guide/blob/main/DOCS/adding-faq.md)
+- Add a new [exercise](https://github.com/thoughtbot/design-sprint-guide/blob/main/DOCS/sprint-guide/adding-exercises.md)
+- Add a new [schedule](https://github.com/thoughtbot/design-sprint-guide/blob/main/DOCS/sprint-guide/adding-schedules.md)
+- Add a new [glossary term](https://github.com/thoughtbot/design-sprint-guide/blob/main/DOCS/sprint-guide/adding-glossary.md)
+- Add a new [FAQ](https://github.com/thoughtbot/design-sprint-guide/blob/main/DOCS/sprint-guide/adding-faq.md)
 
 ## Ideas
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,61 +8,6 @@ for tracking our work on the repository. Here are the ways that you can contribu
 We ask that you abide by our [code of conduct](https://thoughtbot.com/open-source-code-of-conduct)
 when contributing to the guide.
 
-## Structure
-
-We use the following structure to store content:
-
-```
-├── _data
-│   ├── faqs.json // add FAQs into here
-│   ├── schedules // add new schedules into here
-│   │   ├── *.json
-├── _includes
-│   ├── assets // static resources
-│   │   ├── fonts
-│   │   ├── images
-│   │   ├── sass
-│   ├── *.njk // reusable components
-│   ├── layouts
-│   │   ├── *.njk // reusable page layouts
-├── _site // eleventy output, don't edit
-├── admin
-│   ├── config.yml // conifgure Netlify CMS
-│   ├── index.html
-├── css // SASS output, don't edit
-├── exercises // add exercises here
-│   ├── *.md // exercise
-│   ├── exercises.json // apply layout to every exercise
-│   ├── index // exercises index page
-│   │   ├── _introduction.md // edit the index introduction
-│   │   ├── index.njk
-├── glossary // add new glossary here
-│   ├── *.md
-│   ├── glossary.json // apply layout and tags to every entry
-│   ├── index.njk // lists whole glossary
-├── phases // add new phases here
-│   ├── [phase]
-│   │   ├── _introduction.md // edit the index introduction
-│   │   ├── index.njk
-│   ├── phases.json // apply layout and tags to every phase
-├── resources // add new resources here
-│   ├── *.md
-│   ├── index // resources index page
-│   │   ├── _introduction.md // edit the index introduction
-│   │   ├── index.njk
-├── schedules // display new schedules here
-│   ├── [schedule]
-│   │   ├── _introduction.md // edit the index introduction
-│   │   ├── index.njk
-│   ├── index // schedule index page
-│   │   ├── _introduction.md // edit the index introduction
-│   │   ├── index.njk
-│   ├── schedules.json // apply layout and tags to every schedule
-├── .eleventy // configure eleventy
-├── .eleventyignore // tell eleventy to ignore files
-├── netlify.toml // configure netlify deploys
-```
-
 ## Maintenance and Improvements
 
 If you find a bug, misspelling or other problem with anything please add

--- a/DOCS/sprint-guide/adding-resource.md
+++ b/DOCS/sprint-guide/adding-resource.md
@@ -1,0 +1,28 @@
+# Adding a New Resource
+
+1. Open the `_data/resources/[type].json` file. The resources are split by:
+    - Reading: Things that are mostly text based e.g. blog posts and books
+    - Software: This can be either downloadable apps or web apps.
+    - Templates: Things that people can base their own work on or modifiy freely.
+2. Add a new Resource in the following format:
+
+```json
+[
+  ...other resources
+  {
+    "title": "thoughtbot Blog",
+    "description": "Our very own blog that covers all...",
+    "url": "https://thoughtbot.com/blog/design",
+    "icon": "/images/resources/tb-blog_cover.svg",
+    "tags": [
+      "Blog"
+    ]
+  },
+]
+```
+
+## Tips
+
+- You can add more than one tag.
+- Prefer SVG images as they are generally smaller and responsive.
+- Optimise any new images added as much as you can.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This will start Eleventy, watch sass files, run the CMS locally, and reload the 
 
 ### Access the CMS
 
-We use [Netlify CMS](https://www.netlifycms.org) locally to make editing
+We use [Decap CMS](https://decapcms.org) locally to make editing
 exercises, and schedules easier.
 
 To access the CMS run everything above. Then open `localhost:8080/admin` in a


### PR DESCRIPTION
A bit of house keeping for the docs:

- Remove references to Netlify CMS (now [Decap](https://www.netlify.com/blog/netlify-cms-to-become-decap-cms/))
- Update the 404-ing links to docs.
- Remove the structure tree (this going to be too hard to maintain.
- Add docs for adding a new resource.