### PR TITLE
Fix the display of resources on the sprint-guide

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -29,6 +29,12 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addFilter("getChildExercise", function(collection, child) {
     return collection.find((exercise) => exercise.fileSlug === child);
   });
+  // Remove the preceding "/_includes/assets/" from images set in the CMS
+  eleventyConfig.addFilter("normalizeCMSImage", function(url) {
+    const parts = url.split("/")
+    const result = "/" + parts.slice(3).join("/")
+    return result
+  });
   // Generate a simple breadcrumb
   // Usage: {% breadcrumbs page.url %}
   eleventyConfig.addShortcode("breadcrumbs", function(url) {

--- a/sprint-guide/index.njk
+++ b/sprint-guide/index.njk
@@ -130,10 +130,10 @@ layout: 'layouts/base'
       <div class="tbds-inline-stack__item">
         <h4>Software</h4>
         <ul role="list">
-          {% for item in resources.software %}
+          {% for item in resources.software.resources %}
           {% if loop.index0 < 2 %}
           <li class="resource">
-            <img class="software__logo" src="{{ item.icon }}" alt="Icon for {{ item.title }}" />
+            <img class="software__logo" src="{{ item.icon | normalizeCMSImage }}" alt="Icon for {{ item.title }}" />
             <div>
               <h3>{{ item.title }}</h3>
               <p>
@@ -151,10 +151,10 @@ layout: 'layouts/base'
       <div class="tbds-inline-stack__item">
         <h4>Reading</h4>
         <ul role="list">
-          {% for item in resources.reading %}
+          {% for item in resources.reading.resources %}
           {% if loop.index0 < 2 %}
           <li class="resource">
-            <img class="book__logo" src="{{ item.icon }}" alt="Icon for {{ item.title }}" />
+            <img class="book__logo" src="{{ item.icon | normalizeCMSImage }}" alt="Icon for {{ item.title }}" />
             <div>
               <h3>{{ item.title }}</h3>
               <p>

--- a/sprint-guide/resources/index.njk
+++ b/sprint-guide/resources/index.njk
@@ -22,9 +22,9 @@ eleventyExcludeFromCollections: true
 
 <h2 id="software">Software & Tools</h2>
 <ul role="list">
-  {% for item in resources.software %}
+  {% for item in resources.software.resources %}
   <li class="resource">
-    <img class="software__logo" src="{{ item.icon }}" alt="Icon for {{ item.title }}" />
+    <img class="software__logo" src="{{ item.icon | normalizeCMSImage }}" alt="Icon for {{ item.title }}" />
     <div>
       <h3>{{ item.title }}</h3>
       <p>
@@ -40,9 +40,9 @@ eleventyExcludeFromCollections: true
 
 <h2 id="reading">Reading</h2>
 <ul role="list">
-  {% for item in resources.reading %}
+  {% for item in resources.reading.resources %}
   <li class="resource">
-    <img class="book__logo" src="{{ item.icon }}" alt="Logo for {{ item.title }}" />
+    <img class="book__logo" src="{{ item.icon | normalizeCMSImage }}" alt="Logo for {{ item.title }}" />
     <div>
       <h3>{{ item.title }}</h3>
       <p>
@@ -59,9 +59,9 @@ eleventyExcludeFromCollections: true
 <h2 id="templates">Templates</h2>
 <p>For more up-to-date schedule templates see our full list of <a href="/sprint-guide/schedules">Schedules</a></p>
 <ul role="list">
-  {% for item in resources.templates %}
+  {% for item in resources.templates.resources %}
   <li class="resource">
-    <img class="template__logo" src="{{ item.icon }}" alt="Icon for {{ item.title }}" />
+    <img class="template__logo" src="{{ item.icon | normalizeCMSImage }}" alt="Icon for {{ item.title }}" />
     <div>
       <h3>{{ item.title }}</h3>
       <p>


### PR DESCRIPTION
Fixes #101 

## Issue

After moving the resources into the CMS, they no longer displayed.

## Fix

- Update the nunchucks templates to reflect the new JSON structure output by the CMS
- Add a filter to make the image URL output by the CMS not cause 404s.

***

I've testing that this deploy is working on Netlify. Once this gets merged we can unfreeze auto-deploy.