### PR TITLE
Add a setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if command -v asdf > /dev/null; then
+  asdf plugin add nodejs || true
+  asdf plugin add yarn || true
+  asdf plugin update --all || true
+  asdf install
+fi
+
+npm install


### PR DESCRIPTION
This commit adds a setup script for the project. During setup, we handle cases where `asdf` might be available on the local development machine or not.