### PR TITLE
Fix path to 'Critical Path' exercise

### DIFF
--- a/_data/sprint_guide/tabs.json
+++ b/_data/sprint_guide/tabs.json
@@ -24,7 +24,7 @@
       },
       {
         "title": "Critical path",
-        "slug": "make-a-map"
+        "slug": "critical-path"
       },
       {
         "title": "5 Why's",


### PR DESCRIPTION
What?
=====

This adjusts the path for the Critical Path exercise under the [Design sprint phases](https://design.thoughtbot.com/sprint-guide/#understand) section of the homepage.
